### PR TITLE
Wrap setAreaCode in Try Catch Blocks

### DIFF
--- a/src/Profiler/Console/Command/AllowIpsCommand.php
+++ b/src/Profiler/Console/Command/AllowIpsCommand.php
@@ -2,6 +2,7 @@
 namespace Mirasvit\Profiler\Console\Command;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Mirasvit\Profiler\Model\Config;
@@ -57,7 +58,9 @@ class AllowIpsCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->appState->setAreaCode('empty');
+        try{
+            $this->appState->setAreaCode('empty');
+        }catch (LocalizedException $e){}
 
         if (!$input->getOption('none')) {
             $addresses = $input->getArgument('ip');

--- a/src/Profiler/Console/Command/DisableCommand.php
+++ b/src/Profiler/Console/Command/DisableCommand.php
@@ -2,6 +2,7 @@
 namespace Mirasvit\Profiler\Console\Command;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Mirasvit\Profiler\Model\Config;
@@ -39,7 +40,9 @@ class DisableCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->appState->setAreaCode('empty');
+        try{
+            $this->appState->setAreaCode('empty');
+        }catch (LocalizedException $e){}
 
         $this->config->disableProfiler();
     }

--- a/src/Profiler/Console/Command/EnableCommand.php
+++ b/src/Profiler/Console/Command/EnableCommand.php
@@ -2,6 +2,7 @@
 namespace Mirasvit\Profiler\Console\Command;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Mirasvit\Profiler\Model\Config;
@@ -39,7 +40,9 @@ class EnableCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->appState->setAreaCode('empty');
+        try{
+            $this->appState->setAreaCode('empty');
+        }catch (LocalizedException $e){}
 
         $this->config->enableProfiler();
     }

--- a/src/Profiler/Console/Command/StatusCommand.php
+++ b/src/Profiler/Console/Command/StatusCommand.php
@@ -2,6 +2,7 @@
 namespace Mirasvit\Profiler\Console\Command;
 
 use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Mirasvit\Profiler\Model\Config;
@@ -41,7 +42,9 @@ class StatusCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->appState->setAreaCode('empty');
+        try{
+            $this->appState->setAreaCode('empty');
+        }catch (LocalizedException $e){}
 
         $output->writeln('<info>Status: ' . ($this->config->isEnabled() ? 'Enabled' : 'Disabled') . '</info>');
         $output->writeln('<info>IPs: ' . implode(', ', $this->config->getAddressInfo()) . '</info>');


### PR DESCRIPTION
Wrapped setAreaCode in try catch blocks to catch exceptions thrown when areas have already been set