### PR TITLE
:bug: Fix `phpinfo()` call crash

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -1,12 +1,12 @@
 <?php
 if (PHP_SAPI != 'cli') {
-    $_SERVER['MAGE_PROFILER_STAT'] = new \Magento\Framework\Profiler\Driver\Standard\Stat();
+    $GLOBALS['MAGE_PROFILER_STAT'] = new \Magento\Framework\Profiler\Driver\Standard\Stat();
     \Magento\Framework\Profiler::applyConfig(
         [
             'drivers' => [
                 [
                     'output' => 'Mirasvit\Profiler\Model\Driver\Output\Html',
-                    'stat'   => $_SERVER['MAGE_PROFILER_STAT'],
+                    'stat'   => $GLOBALS['MAGE_PROFILER_STAT'],
                 ]
             ]
         ],

--- a/src/Profiler/Model/Profile/Magento.php
+++ b/src/Profiler/Model/Profile/Magento.php
@@ -21,6 +21,6 @@ class Magento implements ProfileInterface
      */
     public function getStat()
     {
-        return $_SERVER['MAGE_PROFILER_STAT'];
+        return $GLOBALS['MAGE_PROFILER_STAT'];
     }
 }


### PR DESCRIPTION
`phpinfo()` displays all information in `$_SERVER`, but `\Magento\Framework\Profiler\Driver\Standard\Stat` does not have `__toString()` method implemented

As a consequence, any following call to `phpinfo()` will crash. This PR does save this object in `$GLOBALS` instead of `$_SERVER` because that's the PHP-recommended place to save global variables.