### PR TITLE
Added FlameChart view for profiler

### DIFF
--- a/src/Profiler/view/base/templates/tab/code.phtml
+++ b/src/Profiler/view/base/templates/tab/code.phtml
@@ -1,10 +1,8 @@
 <?php
 /** @var \Mirasvit\Profiler\Block\Tab\Code $block */
 
-use Magento\Framework\Profiler\Driver\Standard\Stat;
 use Mirasvit\Profiler\Profile\General;
 
-$dump = $block->getCodeDump();
 $general = $block->getGeneralDump();
 
 /** @var \Mirasvit\Profiler\Helper\Format $format */
@@ -18,6 +16,7 @@ $format = $this->helper(\Mirasvit\Profiler\Helper\Format::class);
     <strong><?= $format->formatTime($general[General::DB_TIME]) ?> ms</strong>
     <i>Database Time</i>
 </div>
+
 
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.11/dist/d3.flameGraph.min.css">
 <div id="chart"></div>
@@ -60,47 +59,4 @@ $format = $this->helper(\Mirasvit\Profiler\Helper\Format::class);
   d3.select("#chart")
     .datum(flameGraphJson)
     .call(flamegraph);
-
-
-
 </script>
-
-<div style="display:none;">
-  <table id="code-table">
-      <thead>
-      <tr>
-          <th>Timer</th>
-          <th>Time <sup>ms</sup></th>
-          <th>Avg Time <sup>ms</sup></th>
-          <th>Count</th>
-      </tr>
-      </thead>
-      <tbody>
-      <?php $idx = 0 ?>
-      <?php foreach ($dump as $timerId => $item): ?>
-          <tr data-tt-id="<?= $timerId ?>" data-tt-parent-id="<?= $block->getParentTimerId($timerId) ?>"
-              data-threshold-value="<?= $item[Stat::TIME] * 1000 ?>">
-              <td>
-                  <?php for ($i = 0; $i < $block->getLevel($timerId); $i++): ?>
-                      <?= str_repeat('·', 10) ?>&nbsp;x
-                  <?php endfor ?>
-                  <?= $block->renderTimerId($timerId) ?>
-              </td>
-              <td class="text-right">
-                  <?= $format->formatTime($item[Stat::TIME], true) ?>
-                  <div class="timer-line" style="width: <?= $block->getTimerLength($timerId) ?>%;"></div>
-              </td>
-              <td class="text-right">
-                  <?= $format->formatTime($item[Stat::TIME] / $item[Stat::COUNT], true) ?>
-              </td>
-              <td class="text-right"><?= $item[Stat::COUNT] ?></td>
-          </tr>
-      <?php endforeach ?>
-      </tbody>
-  </table>
-  <script>
-      $(function () {
-          $("#code-table").tablesorter();
-      });
-  </script>
-</div>

--- a/src/Profiler/view/base/templates/tab/code.phtml
+++ b/src/Profiler/view/base/templates/tab/code.phtml
@@ -8,7 +8,7 @@ $dump = $block->getCodeDump();
 $general = $block->getGeneralDump();
 
 /** @var \Mirasvit\Profiler\Helper\Format $format */
-$format = $this->helper('Mirasvit\Profiler\Helper\Format');
+$format = $this->helper(\Mirasvit\Profiler\Helper\Format::class);
 ?>
 <div class="metric">
     <strong><?= $format->formatTime($general[General::EXECUTION_TIME]) ?> ms</strong>
@@ -19,40 +19,88 @@ $format = $this->helper('Mirasvit\Profiler\Helper\Format');
     <i>Database Time</i>
 </div>
 
-<table id="code-table">
-    <thead>
-    <tr>
-        <th>Timer</th>
-        <th>Time <sup>ms</sup></th>
-        <th>Avg Time <sup>ms</sup></th>
-        <th>Count</th>
-    </tr>
-    </thead>
-    <tbody>
-    <?php $idx = 0 ?>
-    <?php foreach ($dump as $timerId => $item): ?>
-        <tr data-tt-id="<?= $timerId ?>" data-tt-parent-id="<?= $block->getParentTimerId($timerId) ?>"
-            data-threshold-value="<?= $item[Stat::TIME] * 1000 ?>">
-            <td>
-                <?php for ($i = 0; $i < $block->getLevel($timerId); $i++): ?>
-                    <?= str_repeat('·', 10) ?>&nbsp;
-                <?php endfor ?>
-                <?= $block->renderTimerId($timerId) ?>
-            </td>
-            <td class="text-right">
-                <?= $format->formatTime($item[Stat::TIME], true) ?>
-                <div class="timer-line" style="width: <?= $block->getTimerLength($timerId) ?>%;"></div>
-            </td>
-            <td class="text-right">
-                <?= $format->formatTime($item[Stat::TIME] / $item[Stat::COUNT], true) ?>
-            </td>
-            <td class="text-right"><?= $item[Stat::COUNT] ?></td>
-        </tr>
-    <?php endforeach ?>
-    </tbody>
-</table>
-<script>
-    $(function () {
-        $("#code-table").tablesorter();
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.11/dist/d3.flameGraph.min.css">
+<div id="chart"></div>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.10.0/d3.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@1.0.11/dist/d3.flameGraph.min.js"></script>
+<script type="text/javascript">
+  const flameGraphJson = <?= $block->getFlameGraphJson(); ?>;
+  const flamegraph = d3.flameGraph()
+    .width(1400)
+    // .height(1080)
+    // .cellHeight(18)
+    .transitionEase(d3.easeCubic)
+    .sort(false)
+    .title("")
+    .reversed(true);
+
+  const tip = d3.tip()
+    .direction("s")
+    .offset([8, 0])
+    .attr('class', 'd3-flame-graph-tip')
+    .html((d) => {
+      const ms = Math.round((d.data.sum/d.data.count * 1000));
+      console.log(d.data);
+      const memory = d.data.realmem ? `Memory: ${formatBytes(d.data.realmem)}` : '';
+      return `${d.data.name}<br />${d.data.count}x${ms}ms ${memory}`;
     });
+
+  function formatBytes(bytes,decimals) {
+    if(bytes == 0) return '0 Bytes';
+    var k = 1024,
+      dm = decimals || 2,
+      sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+      i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  }
+
+  flamegraph.tooltip(tip);
+
+  d3.select("#chart")
+    .datum(flameGraphJson)
+    .call(flamegraph);
+
+
+
 </script>
+
+<div style="display:none;">
+  <table id="code-table">
+      <thead>
+      <tr>
+          <th>Timer</th>
+          <th>Time <sup>ms</sup></th>
+          <th>Avg Time <sup>ms</sup></th>
+          <th>Count</th>
+      </tr>
+      </thead>
+      <tbody>
+      <?php $idx = 0 ?>
+      <?php foreach ($dump as $timerId => $item): ?>
+          <tr data-tt-id="<?= $timerId ?>" data-tt-parent-id="<?= $block->getParentTimerId($timerId) ?>"
+              data-threshold-value="<?= $item[Stat::TIME] * 1000 ?>">
+              <td>
+                  <?php for ($i = 0; $i < $block->getLevel($timerId); $i++): ?>
+                      <?= str_repeat('·', 10) ?>&nbsp;x
+                  <?php endfor ?>
+                  <?= $block->renderTimerId($timerId) ?>
+              </td>
+              <td class="text-right">
+                  <?= $format->formatTime($item[Stat::TIME], true) ?>
+                  <div class="timer-line" style="width: <?= $block->getTimerLength($timerId) ?>%;"></div>
+              </td>
+              <td class="text-right">
+                  <?= $format->formatTime($item[Stat::TIME] / $item[Stat::COUNT], true) ?>
+              </td>
+              <td class="text-right"><?= $item[Stat::COUNT] ?></td>
+          </tr>
+      <?php endforeach ?>
+      </tbody>
+  </table>
+  <script>
+      $(function () {
+          $("#code-table").tablesorter();
+      });
+  </script>
+</div>


### PR DESCRIPTION
Allows us to create profiler charts like this: http://cloud.h-o.nl/rI1W

![schermafbeelding 2018-05-02 om 17 54 05-1](https://user-images.githubusercontent.com/1244416/39590951-99c91984-4f02-11e8-90da-1f2b57a5288d.png)

It could still use some work, but it was way more helpfull than the current table, which was way to big to say anything usefull.

Possible improvements:
- Memory Flame Chart, where not the time, but the memory usage is displayed as width.
- Bottom up flame chart: Multiple sections can call the same eventual method, grouping those together would be nice (not sure how that would look)
- Mouse controll: zoom + scroll like in Chrome Inspector.
- Integrate queries
- Colorcode types of profiles: templates, queries, \Template classes, dataprofiler, etc. Support for the profiler tags.