### PR TITLE
Change root.phtml view to use Magento getViewFileUrl

### DIFF
--- a/src/Profiler/view/base/templates/root.phtml
+++ b/src/Profiler/view/base/templates/root.phtml
@@ -3,9 +3,7 @@
 <head>
     <script src="//code.jquery.com/jquery-3.2.1.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.28.15/js/jquery.tablesorter.min.js"></script>
-    <style>
-        <?=file_get_contents(dirname(dirname(__FILE__)) . '/web/css/module.css') ?>
-    </style>
+    <link rel="stylesheet" href="<? echo $this->getViewFileUrl('Mirasvit_Profiler::css/module.css')?>">
 </head>
 <body>
 <?= $layoutContent ?>


### PR DESCRIPTION
Swap to use getViewFileUrl

Using magento 2.1.10 with composer your module failed to load for me, complaning it couldn't find files because in production mode your profiler isn't expecting the __DIR__ for root.phtml to be in /var/view_processed.

Switching to this method should ensure that your module won't fail on production mode, at least not for the above reason.