### PR TITLE
[BUGFIX] None Magento CLI programs crashes

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -1,7 +1,7 @@
 <?php
 $_SERVER['MAGE_PROFILER_STAT'] = new \Magento\Framework\Profiler\Driver\Standard\Stat();
 
-$canEnable = true;
+$canEnable = defined('BP');
 
 if (PHP_SAPI == 'cli') {
     global $argv;


### PR DESCRIPTION
When running none Magento 2 programs in the CLI it crashes because the ObjectManager isn't initialized.

We maybe need to add another check if its Magento, because BP is pretty generic and other programs can use this as well.