### PR TITLE
Add compatibility with Magento Cloud - Fix: "ObjectManager isn't initialized" on deploy

### DIFF
--- a/src/Profiler/Model/Driver/Output/Html.php
+++ b/src/Profiler/Model/Driver/Output/Html.php
@@ -14,7 +14,11 @@ class Html implements OutputInterface
      */
     public function display(Stat $stat)
     {
-        $objectManager = ObjectManager::getInstance();
+        try {
+            $objectManager = ObjectManager::getInstance();
+        } catch (\RuntimeException $e) {
+            return;
+        }
 
         /** @var \Mirasvit\Profiler\Model\Config $config */
         $config = $objectManager->get('Mirasvit\Profiler\Model\Config');
@@ -32,7 +36,7 @@ class Html implements OutputInterface
         if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], 'profiler') !== false) {
             return;
         }
-        
+
         /** @var \Mirasvit\Profiler\Model\Storage $storage */
         $storage = $objectManager->get('Mirasvit\Profiler\Model\Storage');
 


### PR DESCRIPTION
Without this, the following PHP Fatal error is encountered when deploying to Magento Cloud instances during the phase which runs `vendor/bin/ece-patches apply`.

> PHP Fatal error:  Uncaught RuntimeException: ObjectManager isn't initialized in /var/www/html/vendor/magento/framework/App/ObjectManager.php:36
> Stack trace:
> #0 /var/www/html/vendor/mirasvit/module-profiler/src/Profiler/Model/Driver/Output/Html.php(18): Magento\Framework\App\ObjectManager::getInstance()
> #1 /var/www/html/vendor/magento/framework/Profiler/Driver/Standard.php(195): Mirasvit\Profiler\Model\Driver\Output\Html->display(Object(Magento\Framework\Profiler\Driver\Standard\Stat))
> #2 [internal function]: Magento\Framework\Profiler\Driver\Standard->display()
> #3 {main}
>   thrown in /var/www/html/vendor/magento/framework/App/ObjectManager.php on line 36
>
> Fatal error: Uncaught RuntimeException: ObjectManager isn't initialized in /var/www/html/vendor/magento/framework/App/ObjectManager.php:36
> Stack trace:
> #0 /var/www/html/vendor/mirasvit/module-profiler/src/Profiler/Model/Driver/Output/Html.php(18): Magento\Framework\App\ObjectManager::getInstance()
> #1 /var/www/html/vendor/magento/framework/Profiler/Driver/Standard.php(195): Mirasvit\Profiler\Model\Driver\Output\Html->display(Object(Magento\Framework\Profiler\Driver\Standard\Stat))
> #2 [internal function]: Magento\Framework\Profiler\Driver\Standard->display()
> #3 {main}
>   thrown in /var/www/html/vendor/magento/framework/App/ObjectManager.php on line 36
